### PR TITLE
atualizado links de serviços no ambiente de homologação de MS

### DIFF
--- a/config/cte_ws2.xml
+++ b/config/cte_ws2.xml
@@ -27,14 +27,14 @@
 <UF>
     <sigla>MS</sigla>
     <homologacao>
-        <CteRecepcao method='CTeRecepcao' operation='CteRecepcao' version='2.00'>https://homologacao.cte.ms.gov.br/cteWEB/CteRecepcao.asmx</CteRecepcao>
-        <CteRetRecepcao method='CTeRetRecepcao' operation='CteRetRecepcao' version='2.00'>https://homologacao.cte.ms.gov.br/cteWEB/CteRetRecepcao.asmx</CteRetRecepcao>
-        <CteCancelamento method='CTeCancelamento' operation='CteCancelamento' version='2.00'>https://homologacao.cte.ms.gov.br/cteWEB/CteCancelamento.asmx</CteCancelamento>
-        <CteInutilizacao method='CTeInutilizacao' operation='CteInutilizacao' version='2.00'>https://homologacao.cte.ms.gov.br/cteWEB/CteInutilizacao.asmx</CteInutilizacao>
-        <CteConsultaProtocolo method='cteConsultaCT' operation='CteConsultaProtocolo' version='2.00'>https://homologacao.cte.ms.gov.br/cteWEB/CteConsulta.asmx</CteConsultaProtocolo>
-        <CteStatusServico method='CTeStatusServico' operation='CteStatusServico' version='2.00'>https://homologacao.cte.ms.gov.br/cteWEB/CteStatusServico.asmx</CteStatusServico>
-        <CTeConsultaCadastro method='CTeConsultaCadastro' operation='CTeConsultaCadastro' version='2.00'>https://homologacao.cte.ms.gov.br/cteWEB/CadConsultaCadastro.asmx</CTeConsultaCadastro>
-        <CteRecepcaoEvento method='cteRecepcaoEvento' operation='CteRecepcaoEvento' version='2.00'>http://homologacao.cte.ms.gov.br/cteWEB/CteRecepcaoEvento.asmx</CteRecepcaoEvento>
+        <CteRecepcao method='CTeRecepcao' operation='CteRecepcao' version='2.00'>https://homologacao.cte.ms.gov.br/ws/CteRecepcao</CteRecepcao>
+        <CteRetRecepcao method='CTeRetRecepcao' operation='CteRetRecepcao' version='2.00'>https://homologacao.cte.ms.gov.br/ws/CteRetRecepcao</CteRetRecepcao>
+        <CteCancelamento method='CTeCancelamento' operation='CteCancelamento' version='2.00'>https://homologacao.cte.ms.gov.br/ws/CteCancelamento</CteCancelamento>
+        <CteInutilizacao method='CTeInutilizacao' operation='CteInutilizacao' version='2.00'>https://homologacao.cte.ms.gov.br/ws/CteInutilizacao</CteInutilizacao>
+        <CteConsultaProtocolo method='cteConsultaCT' operation='CteConsultaProtocolo' version='2.00'>https://homologacao.cte.ms.gov.br/ws/CteConsulta</CteConsultaProtocolo>
+        <CteStatusServico method='CTeStatusServico' operation='CteStatusServico' version='2.00'>https://homologacao.cte.ms.gov.br/ws/CteStatusServico</CteStatusServico>
+        <CTeConsultaCadastro method='CTeConsultaCadastro' operation='CTeConsultaCadastro' version='2.00'>https://homologacao.cte.ms.gov.br/ws/CadConsultaCadastro</CTeConsultaCadastro>
+        <CteRecepcaoEvento method='cteRecepcaoEvento' operation='CteRecepcaoEvento' version='2.00'>https://homologacao.cte.ms.gov.br/ws/CteRecepcaoEvento</CteRecepcaoEvento>
     </homologacao>
     <producao>
         <CteRecepcao method='CTeRecepcao' operation='CteRecepcao' version='2.00'>https://producao.cte.ms.gov.br/ws/CteRecepcao</CteRecepcao>


### PR DESCRIPTION
Segue mudanças nos links do serviço de homologação do SEFAZ MS, conforme: http://www.cte.ms.gov.br/desativacao-em-19jan2016-homologacao-e-01032016-producao-do-ambiente-de-autorizacao-do-conhecimento-de-transporte-eletronico-ct-e/