### PR TITLE
ajustado valor do parametro 'tipo' do método 'assinaDoc()' para lowercase

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -60,7 +60,7 @@ class Tools extends BaseTools
      */
     public function assina($xml = '', $saveFile = false)
     {
-        return $this->assinaDoc($xml, 'CTe', 'infCte', $saveFile);
+        return $this->assinaDoc($xml, 'cte', 'infCte', $saveFile);
     }
 
     public function sefazEnvia(


### PR DESCRIPTION
Corrigindo devido não estar batendo com os valores de comparação na classe BaseTools que por consequência não permitia encontrar os caminhos para os xmls, que esta atualmente assim:

    private function zGetXmlUrlPath($tipo)
    {
        $path = '';
        if ($tipo == 'nfe') {
            $path = $this->aConfig['pathXmlUrlFileNFe'];
            if ($this->modelo == '65') {
                $path = str_replace('55', '65', $path);
            } else {
                $path = str_replace('65', '55', $path);
            }
        } elseif ($tipo == 'cte') {
            $path = $this->aConfig['pathXmlUrlFileCTe'];
        } elseif ($tipo == 'mdfe') {
            $path = $this->aConfig['pathXmlUrlFileMDFe'];
        } elseif ($tipo == 'cle') {
            $path = $this->aConfig['pathXmlUrlFileCLe'];
        }
        
        $pathXmlUrlFile = NFEPHP_ROOT
            . DIRECTORY_SEPARATOR
            . 'config'
            . DIRECTORY_SEPARATOR
            . $path;
        
        return $pathXmlUrlFile;
    }