### PR TITLE
Trocado obrigatoriedade do campo xFant do emitente para 'false'

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -1553,7 +1553,7 @@ class Make extends BaseMake
             $this->emit,
             'xFant',
             $xFant,
-            true,
+            false,
             $identificador . 'Nome fantasia'
         );
         return $this->emit;


### PR DESCRIPTION
Baseado no Manual do CTe v2.00a esse campo não é obrigatório devido emitente poder ser uma pessoa física.