### PR TITLE
Fix/make remetente

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -1729,7 +1729,7 @@ class Make extends BaseMake
             $this->rem,
             'xFant',
             $xFant,
-            true,
+            false,
             $identificador . 'Nome fantasia'
         );
         $this->dom->addChild(


### PR DESCRIPTION
Baseado no Manual do CTe v2.00a o campo xFant não é obrigatório, logo passei para false para não adicionar um campo vazio que posteriormente da erro na validação.