### PR TITLE
Correção - Evento Carta de Correção

### DIFF
--- a/examples/testaCartaCorrecao.php
+++ b/examples/testaCartaCorrecao.php
@@ -22,12 +22,6 @@ $aResposta = array();
 // utilizar 90 para identificar SUFRAMA
 $siglaUF = $cteTools->aConfig['siglaUF'];
 
-// Identificação do Ambiente: 1 – Produção 2 – Homologação
-$tpAmb = '2';
-
-// Informar o CNPJ do autor do Evento
-$cnpj = $cteTools->aConfig['cnpj'];
-
 // Chave de Acesso do CT-e vinculado ao Evento
 $chave = '41160981450900000132570020000000601000000106';
 
@@ -56,10 +50,8 @@ $nroItemAlterado='01';
 
 // Transmite o arquivo
 $cteTools->sefazCartaCorrecao(
-    $siglaUF,
-    $tpAmb,
-    $cnpj,
     $chave,
+    $tpAmb,        
     $nSeqEvento,
     $grupoAlterado,
     $campoAlterado,

--- a/src/Tools.php
+++ b/src/Tools.php
@@ -566,14 +566,14 @@ class Tools extends BaseTools
         $this->soapDebug = $this->oSoap->soapDebug;
         //salva mensagens
         $filename = "$chCTe-$aliasEvento-envEvento.xml";
-        $this->zGravaFile('cte', $tpAmb, $filename, $lastMsg);        
+        $this->zGravaFile('cte', $tpAmb, $filename, $lastMsg);
         $filename = "$chCTe-$aliasEvento-retEnvEvento.xml";
         $this->zGravaFile('cte', $tpAmb, $filename, $retorno);
         //tratar dados de retorno
         $this->aLastRetEvent = Response::readReturnSefaz($servico, $retorno);
-        if ($this->aLastRetEvent['cStat'] == '134' || 
+        if ($this->aLastRetEvent['cStat'] == '134' ||
                 $this->aLastRetEvent['cStat'] == '135' ||
-                $this->aLastRetEvent['cStat'] == '136'){            
+                $this->aLastRetEvent['cStat'] == '136') {
             $pasta = 'eventos'; //default
             if ($aliasEvento == 'CanCTe') {
                 $pasta = 'canceladas';
@@ -583,7 +583,7 @@ class Tools extends BaseTools
                 $filename = "$chCTe-$aliasEvento-$nSeqEvento-procEvento.xml";
             }
             $retorno = $this->zAddProtMsg('procEventoCTe', 'eventoCTe', $signedMsg, 'retEventoCTe', $retorno);
-            $this->zGravaFile('cte', $tpAmb, $filename, $retorno, $pasta);            
+            $this->zGravaFile('cte', $tpAmb, $filename, $retorno, $pasta);
         }
         return (string) $retorno;
     }
@@ -749,9 +749,9 @@ class Tools extends BaseTools
      * II - a correção de dados cadastrais que implique mudança do emitente,
      *  tomador, remetente ou do destinatário;
      * III - a data de emissão ou de saída.
-     *     
+     *
      * @param type $chCTe
-     * @param type $tpAmb        
+     * @param type $tpAmb
      * @param type $nSeqEvento
      * @param type $grupoAlterado
      * @param type $campoAlterado
@@ -763,7 +763,7 @@ class Tools extends BaseTools
      */
     public function sefazCartaCorrecao(
         $chCTe = '',
-        $tpAmb = '2',        
+        $tpAmb = '2',
         $nSeqEvento = '1',
         $grupoAlterado = '',
         $campoAlterado = '',

--- a/src/Tools.php
+++ b/src/Tools.php
@@ -23,6 +23,7 @@ use NFePHP\Common\LotNumber\LotNumber;
 use NFePHP\Common\Strings\Strings;
 use NFePHP\Common\Files;
 use NFePHP\Common\Exception;
+use NFePHP\Common\Dom\Dom;
 use NFePHP\CTe\Auxiliar\Response;
 use NFePHP\CTe\Auxiliar\IdentifyCTe;
 use NFePHP\Common\Dom\ValidXsd;
@@ -41,6 +42,13 @@ class Tools extends BaseTools
      */
     protected $urlPortal = 'http://www.portalfiscal.inf.br/cte';
 
+    /**
+     * aLastRetEvent
+     *
+     * @var array
+     */
+    private $aLastRetEvent = array();
+   
     /**
      * erros
      *
@@ -543,7 +551,7 @@ class Tools extends BaseTools
 
         $signedMsg = $this->oCertificate->signXML($cons, 'infEvento');
         //limpa o xml
-        $signedMsg = preg_replace("/<\?xml.*\?>/", "", $signedMsg);
+        $signedMsg = Strings::clearXml($signedMsg, true);
         //montagem dos dados da mensagem SOAP
         $body = "<cteDadosMsg xmlns=\"$this->urlNamespace\">$signedMsg</cteDadosMsg>";
         
@@ -558,27 +566,24 @@ class Tools extends BaseTools
         $this->soapDebug = $this->oSoap->soapDebug;
         //salva mensagens
         $filename = "$chCTe-$aliasEvento-envEvento.xml";
-        $this->zGravaFile('cte', $tpAmb, $filename, $lastMsg);
+        $this->zGravaFile('cte', $tpAmb, $filename, $lastMsg);        
         $filename = "$chCTe-$aliasEvento-retEnvEvento.xml";
         $this->zGravaFile('cte', $tpAmb, $filename, $retorno);
         //tratar dados de retorno
         $this->aLastRetEvent = Response::readReturnSefaz($servico, $retorno);
-        if ($this->aLastRetEvent['cStat'] == '128') {
-            if ($this->aLastRetEvent['evento'][0]['cStat'] == '135' ||
-                $this->aLastRetEvent['evento'][0]['cStat'] == '136' ||
-                $this->aLastRetEvent['evento'][0]['cStat'] == '155'
-            ) {
-                $pasta = 'eventos'; //default
-                if ($aliasEvento == 'CanCTe') {
-                    $pasta = 'canceladas';
-                    $filename = "$chCTe-$aliasEvento-procEvento.xml";
-                } elseif ($aliasEvento == 'CCe') {
-                    $pasta = 'cartacorrecao';
-                    $filename = "$chCTe-$aliasEvento-$nSeqEvento-procEvento.xml";
-                }
-                $retorno = $this->zAddProtMsg('procEventoCTe', 'evento', $signedMsg, 'retEvento', $retorno);
-                $this->zGravaFile('cte', $tpAmb, $filename, $retorno, $pasta);
+        if ($this->aLastRetEvent['cStat'] == '134' || 
+                $this->aLastRetEvent['cStat'] == '135' ||
+                $this->aLastRetEvent['cStat'] == '136'){            
+            $pasta = 'eventos'; //default
+            if ($aliasEvento == 'CanCTe') {
+                $pasta = 'canceladas';
+                $filename = "$chCTe-$aliasEvento-procEvento.xml";
+            } elseif ($aliasEvento == 'CCe') {
+                $pasta = 'cartacorrecao';
+                $filename = "$chCTe-$aliasEvento-$nSeqEvento-procEvento.xml";
             }
+            $retorno = $this->zAddProtMsg('procEventoCTe', 'eventoCTe', $signedMsg, 'retEventoCTe', $retorno);
+            $this->zGravaFile('cte', $tpAmb, $filename, $retorno, $pasta);            
         }
         return (string) $retorno;
     }
@@ -744,11 +749,9 @@ class Tools extends BaseTools
      * II - a correção de dados cadastrais que implique mudança do emitente,
      *  tomador, remetente ou do destinatário;
      * III - a data de emissão ou de saída.
-     *
-     * @param type $siglaUF
-     * @param type $tpAmb
-     * @param type $cnpj
-     * @param type $chave
+     *     
+     * @param type $chCTe
+     * @param type $tpAmb        
      * @param type $nSeqEvento
      * @param type $grupoAlterado
      * @param type $campoAlterado
@@ -759,10 +762,8 @@ class Tools extends BaseTools
      * @throws Exception\InvalidArgumentException
      */
     public function sefazCartaCorrecao(
-        $siglaUF = '',
-        $tpAmb = '2',
-        $cnpj = '',
-        $chave = '',
+        $chCTe = '',
+        $tpAmb = '2',        
         $nSeqEvento = '1',
         $grupoAlterado = '',
         $campoAlterado = '',
@@ -770,19 +771,21 @@ class Tools extends BaseTools
         $nroItemAlterado = '01',
         &$aRetorno = array()
     ) {
-        $chCTe = preg_replace('/[^0-9]/', '', $chave);
+        $chCTe = preg_replace('/[^0-9]/', '', $chCTe);
         
         //validação dos dados de entrada
         if (strlen($chCTe) != 44) {
             $msg = "Uma chave de CTe válida não foi passada como parâmetro $chCTe.";
             throw new Exception\InvalidArgumentException($msg);
         }
-        if ($siglaUF == '' || $cnpj == '' || $chave == '' ||
-            $grupoAlterado == '' || $campoAlterado == '' || $valorAlterado == ''
-        ) {
+        if ($chCTe == '' || $grupoAlterado == '' || $campoAlterado == '' || $valorAlterado == '') {
             $msg = "Preencha os campos obrigatórios!";
             throw new Exception\InvalidArgumentException($msg);
         }
+        if ($tpAmb == '') {
+            $tpAmb = $this->aConfig['tpAmb'];
+        }
+        $siglaUF = $this->zGetSigla(substr($chCTe, 0, 2));
         
         //estabelece o codigo do tipo de evento CARTA DE CORRECAO
         $tpEvento = '110110';


### PR DESCRIPTION
Este pull request trata da correção do evento Carta de Correção CTe, visto que não era possível gerar o xml com o protocolo da mesma.

- Inclusão de variável

- Modificações no método "zSefazEvento" para atender parâmetros do manual CTe, visto que estava com base na NFe.

- Assim como o método "sefazCartaCorrecao", onde foram removidos parâmetros que julguei serem desnecessários com base nas outras classes NFePHP.

Testado e validado em ambiente de produção.