### PR TITLE
Ajuste carta de correção

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -42,6 +42,13 @@ class Tools extends BaseTools
      * @var string
      */
     protected $urlPortal = 'http://www.portalfiscal.inf.br/cte';
+    
+    /**
+     * aLastRetEvent
+     *
+     * @var array
+     */
+    private $aLastRetEvent = array();
 
     /**
      * @var string

--- a/src/Tools.php
+++ b/src/Tools.php
@@ -573,10 +573,10 @@ class Tools extends BaseTools
 
         $signedMsg = $this->oCertificate->signXML($cons, 'infEvento');
         //limpa o xml
-        $signedMsg = preg_replace("/<\?xml.*\?>/", "", $signedMsg);
+        $signedMsg = Strings::clearXml($signedMsg, true);
         //montagem dos dados da mensagem SOAP
         $body = "<cteDadosMsg xmlns=\"$this->urlNamespace\">$signedMsg</cteDadosMsg>";
-
+        
         $retorno = $this->oSoap->send(
             $this->urlService,
             $this->urlNamespace,
@@ -593,26 +593,69 @@ class Tools extends BaseTools
         $this->zGravaFile('cte', $tpAmb, $filename, $retorno);
         //tratar dados de retorno
         $this->aLastRetEvent = Response::readReturnSefaz($servico, $retorno);
-        if ($this->aLastRetEvent['cStat'] == '128') {
-            if ($this->aLastRetEvent['evento'][0]['cStat'] == '135' ||
-                $this->aLastRetEvent['evento'][0]['cStat'] == '136' ||
-                $this->aLastRetEvent['evento'][0]['cStat'] == '155'
-            ) {
-                $pasta = 'eventos'; //default
-                if ($aliasEvento == 'CanCTe') {
-                    $pasta = 'canceladas';
-                    $filename = "$chCTe-$aliasEvento-procEvento.xml";
-                } elseif ($aliasEvento == 'CCe') {
-                    $pasta = 'cartacorrecao';
-                    $filename = "$chCTe-$aliasEvento-$nSeqEvento-procEvento.xml";
-                }
-                $retorno = $this->zAddProtMsg('procEventoCTe', 'evento', $signedMsg, 'retEvento', $retorno);
-                $this->zGravaFile('cte', $tpAmb, $filename, $retorno, $pasta);
+        if ($this->aLastRetEvent['cStat'] == '134' ||
+                $this->aLastRetEvent['cStat'] == '135' ||
+                $this->aLastRetEvent['cStat'] == '136') {
+            $pasta = 'eventos'; //default
+            if ($aliasEvento == 'CancCTe') {
+                $pasta = 'canceladas';
+                $filename = "$chCTe-$aliasEvento-procEvento.xml";
+            } elseif ($aliasEvento == 'CCe') {
+                $pasta = 'cartacorrecao';
+                $filename = "$chCTe-$aliasEvento-$nSeqEvento-procEvento.xml";
             }
+            $retorno = $this->zAddProtMsg('procEventoCTe', 'eventoCTe', $signedMsg, 'retEventoCTe', $retorno);
+            $this->zGravaFile('cte', $tpAmb, $filename, $retorno, $pasta);
         }
         return (string) $retorno;
     }
+    
+    /**
+     * zAddProtMsg
+     *
+     * @param  string $tagproc
+     * @param  string $tagmsg
+     * @param  string $xmlmsg
+     * @param  string $tagretorno
+     * @param  string $xmlretorno
+     * @return string
+     */
+    protected function zAddProtMsg($tagproc, $tagmsg, $xmlmsg, $tagretorno, $xmlretorno)
+    {
+        $doc = new Dom();
+        $doc->loadXMLString($xmlmsg);
+        $nodedoc = $doc->getNode($tagmsg, 0);
+        $procver = $nodedoc->getAttribute("versao");
+        $procns = $nodedoc->getAttribute("xmlns");
 
+        $doc1 = new Dom();
+        $doc1->loadXMLString($xmlretorno);
+        $nodedoc1 = $doc1->getNode($tagretorno, 0);
+
+        $proc = new \DOMDocument('1.0', 'utf-8');
+        $proc->formatOutput = false;
+        $proc->preserveWhiteSpace = false;
+        //cria a tag nfeProc
+        $procNode = $proc->createElement($tagproc);
+        $proc->appendChild($procNode);
+        //estabele o atributo de versão
+        $procNodeAtt1 = $procNode->appendChild($proc->createAttribute('versao'));
+        $procNodeAtt1->appendChild($proc->createTextNode($procver));
+        //estabelece o atributo xmlns
+        $procNodeAtt2 = $procNode->appendChild($proc->createAttribute('xmlns'));
+        $procNodeAtt2->appendChild($proc->createTextNode($procns));
+        //inclui a tag inutNFe
+        $node = $proc->importNode($nodedoc, true);
+        $procNode->appendChild($node);
+        //inclui a tag retInutNFe
+        $node = $proc->importNode($nodedoc1, true);
+        $procNode->appendChild($node);
+        //salva o xml como string em uma variável
+        $procXML = $proc->saveXML();
+        //remove as informações indesejadas
+        $procXML = Strings::clearProt($procXML);
+        return $procXML;
+    }
 
     /**
      * zTpEv
@@ -729,10 +772,8 @@ class Tools extends BaseTools
      *  tomador, remetente ou do destinatário;
      * III - a data de emissão ou de saída.
      *
-     * @param type $siglaUF
+     * @param type $chCTe
      * @param type $tpAmb
-     * @param type $cnpj
-     * @param type $chave
      * @param type $nSeqEvento
      * @param type $grupoAlterado
      * @param type $campoAlterado
@@ -743,10 +784,8 @@ class Tools extends BaseTools
      * @throws Exception\InvalidArgumentException
      */
     public function sefazCartaCorrecao(
-        $siglaUF = '',
+        $chCTe = '',
         $tpAmb = '2',
-        $cnpj = '',
-        $chave = '',
         $nSeqEvento = '1',
         $grupoAlterado = '',
         $campoAlterado = '',
@@ -754,46 +793,48 @@ class Tools extends BaseTools
         $nroItemAlterado = '01',
         &$aRetorno = array()
     ) {
-        $chCTe = preg_replace('/[^0-9]/', '', $chave);
-
+        $chCTe = preg_replace('/[^0-9]/', '', $chCTe);
+        
         //validação dos dados de entrada
         if (strlen($chCTe) != 44) {
             $msg = "Uma chave de CTe válida não foi passada como parâmetro $chCTe.";
             throw new Exception\InvalidArgumentException($msg);
         }
-        if ($siglaUF == '' || $cnpj == '' || $chave == '' ||
-            $grupoAlterado == '' || $campoAlterado == '' || $valorAlterado == ''
-        ) {
+        if ($chCTe == '' || $grupoAlterado == '' || $campoAlterado == '' || $valorAlterado == '') {
             $msg = "Preencha os campos obrigatórios!";
             throw new Exception\InvalidArgumentException($msg);
         }
-
+        if ($tpAmb == '') {
+            $tpAmb = $this->aConfig['tpAmb'];
+        }
+        $siglaUF = $this->zGetSigla(substr($chCTe, 0, 2));
+        
         //estabelece o codigo do tipo de evento CARTA DE CORRECAO
         $tpEvento = '110110';
         $descEvento = 'Carta de Correcao';
-
+        
         //monta mensagem
         $tagAdic =
             "<evCCeCTe>"
-            . "<descEvento>$descEvento</descEvento>"
-            . "<infCorrecao>"
-            . "<grupoAlterado>$grupoAlterado</grupoAlterado>"
-            . "<campoAlterado>$campoAlterado</campoAlterado>"
-            . "<valorAlterado>$valorAlterado</valorAlterado>"
-            . "<nroItemAlterado>$nroItemAlterado</nroItemAlterado>"
-            . "</infCorrecao>"
-            . "<xCondUso>"
-            . "A Carta de Correcao e disciplinada pelo Art. 58-B do "
-            . "CONVENIO/SINIEF 06/89: Fica permitida a utilizacao de carta de "
-            . "correcao, para regularizacao de erro ocorrido na emissao de "
-            . "documentos fiscais relativos a prestacao de servico de transporte, "
-            . "desde que o erro nao esteja relacionado com: I - as variaveis que "
-            . "determinam o valor do imposto tais como: base de calculo, "
-            . "aliquota, diferenca de preco, quantidade, valor da prestacao;II - "
-            . "a correcao de dados cadastrais que implique mudanca do emitente, "
-            . "tomador, remetente ou do destinatario;III - a data de emissao ou "
-            . "de saida."
-            . "</xCondUso>"
+                . "<descEvento>$descEvento</descEvento>"
+                . "<infCorrecao>"
+                    . "<grupoAlterado>$grupoAlterado</grupoAlterado>"
+                    . "<campoAlterado>$campoAlterado</campoAlterado>"
+                    . "<valorAlterado>$valorAlterado</valorAlterado>"
+                    . "<nroItemAlterado>$nroItemAlterado</nroItemAlterado>"
+                . "</infCorrecao>"
+                . "<xCondUso>"
+                    . "A Carta de Correcao e disciplinada pelo Art. 58-B do "
+                    . "CONVENIO/SINIEF 06/89: Fica permitida a utilizacao de carta de "
+                    . "correcao, para regularizacao de erro ocorrido na emissao de "
+                    . "documentos fiscais relativos a prestacao de servico de transporte, "
+                    . "desde que o erro nao esteja relacionado com: I - as variaveis que "
+                    . "determinam o valor do imposto tais como: base de calculo, "
+                    . "aliquota, diferenca de preco, quantidade, valor da prestacao;II - "
+                    . "a correcao de dados cadastrais que implique mudanca do emitente, "
+                    . "tomador, remetente ou do destinatario;III - a data de emissao ou "
+                    . "de saida."
+                . "</xCondUso>"
             ."</evCCeCTe>";
         $retorno = $this->zSefazEvento($siglaUF, $chCTe, $tpAmb, $tpEvento, $nSeqEvento, $tagAdic);
         $aRetorno = $this->aLastRetEvent;


### PR DESCRIPTION
Segue método corrigido conforme pr #61 
Apenas para considerações:
De acordo com manual CT-e versão 2.00 os eventos não possuem tratamento em lote, como é o caso da NF-e (cStat=128), neste caso o protocolo não era adicionado ao evento.
Também exclusos parâmetros desnecessários ($siglaUF e $cnpj) do método **sefazCartaCorrecao**