### PR TITLE
Ajustes carta de correção

### DIFF
--- a/examples/testaCartaCorrecao.php
+++ b/examples/testaCartaCorrecao.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Arquivo de teste para transmissão de Carta de Correção
  * @copyright  Copyright (c) 2008-2015
@@ -30,33 +31,23 @@ $chave = '41160981450900000132570020000000601000000106';
 // nos casos em que possa existir mais de um evento
 // o autor do evento deve numerar de forma sequencial.
 $nSeqEvento = '1';
-       
-// Indicar o grupo de informações que pertence
-// o campoAlterado. Ex: ide
-$grupoAlterado = 'ide';
 
-// Nome do campo modificado do CT-e Original.
-// Ex: natOp
-$campoAlterado = 'natOp';
-
-// Valor correspondente à alteração.
-$valorAlterado = 'teste de carta de correcao';
-
-// Preencher com o indice do item alterado caso a alteração ocorra em uma lista.
-// Por exemplo: Se corrigir uma das NF-e do remetente, 
-// esta tag deverá indicar a posição da NF-e alterada na lista.
-// OBS: O indice inicia sempre em 01
-$nroItemAlterado='01';
+//As informações da correção devem ser em array
+//O registro de uma nova Carta de Correção substitui a Carta de Correção anterior, assim a nova
+//Carta de Correção deve conter todas as correções a serem consideradas.
+$infCorrecao[] = array(
+    "grupoAlterado" => 'ide', // Indicar o grupo de informações que pertence
+    "campoAlterado" => 'natOp', // Nome do campo modificado do CT-e Original.
+    "valorAlterado" => 'teste de carta de correcao', // Valor correspondente à alteração.
+    "nroItemAlterado" => '1'// Preencher com o indice do item alterado caso a alteração ocorra em uma lista.
+);
 
 // Transmite o arquivo
 $cteTools->sefazCartaCorrecao(
     $chave,
-    $tpAmb,        
+    $tpAmb,
     $nSeqEvento,
-    $grupoAlterado,
-    $campoAlterado,
-    $valorAlterado,
-    $nroItemAlterado,
+    $infCorrecao,
     $aResposta
 );
 

--- a/src/Tools.php
+++ b/src/Tools.php
@@ -782,10 +782,7 @@ class Tools extends BaseTools
      * @param type $chCTe
      * @param type $tpAmb
      * @param type $nSeqEvento
-     * @param type $grupoAlterado
-     * @param type $campoAlterado
-     * @param type $valorAlterado
-     * @param type $nroItemAlterado
+     * @param type $infCorrecao array(array(grupoAlterado => grupo, campoAlterado => campo, valorAlterado=>valor, nroItemAlterado=>nro))
      * @param type $aRetorno
      * @return type
      * @throws Exception\InvalidArgumentException
@@ -794,20 +791,17 @@ class Tools extends BaseTools
         $chCTe = '',
         $tpAmb = '2',
         $nSeqEvento = '1',
-        $grupoAlterado = '',
-        $campoAlterado = '',
-        $valorAlterado = '',
-        $nroItemAlterado = '01',
+        $infCorrecao = array(),
         &$aRetorno = array()
     ) {
         $chCTe = preg_replace('/[^0-9]/', '', $chCTe);
-        
+
         //validação dos dados de entrada
         if (strlen($chCTe) != 44) {
             $msg = "Uma chave de CTe válida não foi passada como parâmetro $chCTe.";
             throw new Exception\InvalidArgumentException($msg);
         }
-        if ($chCTe == '' || $grupoAlterado == '' || $campoAlterado == '' || $valorAlterado == '') {
+        if ($chCTe == '' || empty(array_filter($infCorrecao))) {
             $msg = "Preencha os campos obrigatórios!";
             throw new Exception\InvalidArgumentException($msg);
         }
@@ -815,21 +809,27 @@ class Tools extends BaseTools
             $tpAmb = $this->aConfig['tpAmb'];
         }
         $siglaUF = $this->zGetSigla(substr($chCTe, 0, 2));
-        
+
         //estabelece o codigo do tipo de evento CARTA DE CORRECAO
         $tpEvento = '110110';
         $descEvento = 'Carta de Correcao';
-        
+
+        //Grupo de Informações de Correção
+        $correcoes = '';
+        foreach ($infCorrecao as $info) {
+            $correcoes .=
+                "<infCorrecao>"
+                    ."<grupoAlterado>".$info['grupoAlterado']."</grupoAlterado>"
+                    ."<campoAlterado>".$info['campoAlterado']."</campoAlterado>"
+                    ."<valorAlterado>".$info['valorAlterado']."</valorAlterado>"
+                    ."<nroItemAlterado>".$info['nroItemAlterado']."</nroItemAlterado>"
+                ."</infCorrecao>";
+        }
         //monta mensagem
         $tagAdic =
             "<evCCeCTe>"
                 . "<descEvento>$descEvento</descEvento>"
-                . "<infCorrecao>"
-                    . "<grupoAlterado>$grupoAlterado</grupoAlterado>"
-                    . "<campoAlterado>$campoAlterado</campoAlterado>"
-                    . "<valorAlterado>$valorAlterado</valorAlterado>"
-                    . "<nroItemAlterado>$nroItemAlterado</nroItemAlterado>"
-                . "</infCorrecao>"
+                .$correcoes
                 . "<xCondUso>"
                     . "A Carta de Correcao e disciplinada pelo Art. 58-B do "
                     . "CONVENIO/SINIEF 06/89: Fica permitida a utilizacao de carta de "

--- a/src/Tools.php
+++ b/src/Tools.php
@@ -782,7 +782,7 @@ class Tools extends BaseTools
      * @param type $chCTe
      * @param type $tpAmb
      * @param type $nSeqEvento
-     * @param type $infCorrecao array(array(grupoAlterado => grupo, campoAlterado => campo, valorAlterado=>valor, nroItemAlterado=>nro))
+     * @param type $infCorrecao
      * @param type $aRetorno
      * @return type
      * @throws Exception\InvalidArgumentException


### PR DESCRIPTION
Este pr contém um ajuste no método que faz o envio da carta de correção. 
Para o evento carta de correção do CT-e é necessário informar outras correções que foram enviadas previamente. Sem isto a carta de correção enviada anteriormente será susbtiuída pela próxima.