### PR TITLE
Atualização de "operation" da Consulta por Chave

### DIFF
--- a/config/cte_ws2.xml
+++ b/config/cte_ws2.xml
@@ -10,7 +10,7 @@
         <CteRetRecepcao method='CTeRetRecepcao' operation='CteRetRecepcao' version='2.00'>https://hcte.fazenda.mg.gov.br/cte/services/CteRetRecepcao</CteRetRecepcao>
         <CteCancelamento method='CTeCancelamento' operation='CteCancelamento' version='2.00'>https://hcte.fazenda.mg.gov.br/cte/services/CteCancelamento</CteCancelamento>
         <CteInutilizacao method='CTeInutilizacao' operation='CteInutilizacao' version='2.00'>https://hcte.fazenda.mg.gov.br/cte/services/CteInutilizacao</CteInutilizacao>
-        <CteConsultaProtocolo method='cteConsultaCT' operation='CteConsultaProtocolo' version='2.00'>https://hcte.fazenda.mg.gov.br/cte/services/CteConsulta</CteConsultaProtocolo>
+        <CteConsultaProtocolo method='cteConsultaCT' operation='CteConsulta' version='2.00'>https://hcte.fazenda.mg.gov.br/cte/services/CteConsulta</CteConsultaProtocolo>
         <CteStatusServico method='cteStatusServicoCT' operation='CteStatusServico' version='2.00'>https://hcte.fazenda.mg.gov.br/cte/services/CteStatusServico</CteStatusServico>
         <CteRecepcaoEvento method='cteRecepcaoEvento' operation='CteRecepcaoEvento' version='2.00'>https://hcte.fazenda.mg.gov.br/cte/services/RecepcaoEvento</CteRecepcaoEvento>
     </homologacao>
@@ -19,7 +19,7 @@
         <CteRetRecepcao method='CTeRetRecepcao' operation='CteRetRecepcao' version='2.00'>https://cte.fazenda.mg.gov.br/cte/services/CteRetRecepcao</CteRetRecepcao>
         <CteCancelamento method='CTeCancelamento' operation='CteCancelamento' version='2.00'>https://cte.fazenda.mg.gov.br/cte/services/CteCancelamento</CteCancelamento>
         <CteInutilizacao method='CTeInutilizacao' operation='CteInutilizacao' version='2.00'>https://cte.fazenda.mg.gov.br/cte/services/CteInutilizacao</CteInutilizacao>
-        <CteConsultaProtocolo method='cteConsultaCT' operation='CteConsultaProtocolo' version='2.00'>https://cte.fazenda.mg.gov.br/cte/services/CteConsulta</CteConsultaProtocolo>
+        <CteConsultaProtocolo method='cteConsultaCT' operation='CteConsulta' version='2.00'>https://cte.fazenda.mg.gov.br/cte/services/CteConsulta</CteConsultaProtocolo>
         <CteStatusServico method='cteStatusServicoCT' operation='CteStatusServico' version='2.00'>https://cte.fazenda.mg.gov.br/cte/services/CteStatusServico</CteStatusServico>
         <CteRecepcaoEvento method='cteRecepcaoEvento' operation='CteRecepcaoEvento' version='2.00'>https://cte.fazenda.mg.gov.br/cte/services/RecepcaoEvento</CteRecepcaoEvento>
     </producao>


### PR DESCRIPTION
Corrige o erro na consulta por chave. Só testei pra MG, por isso não troquei dos outros estados. Caso alguém tenha como fazer o teste e o debug retornar: Message part {http://www.portalfiscal.inf.br/cte/wsdl/CteConsultaProtocolo}cteDadosMsg was not recognized.  (Does it exist in service WSDL?) Basta alterar de CteConsultaProtocolo para CteConsulta