### PR TITLE
ajuste para validar

### DIFF
--- a/schemas/PL_CTe_300/tiposGeralCTe_v3.00.xsd
+++ b/schemas/PL_CTe_300/tiposGeralCTe_v3.00.xsd
@@ -351,7 +351,7 @@
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
 			<xs:maxLength value="14"/>
-			<xs:pattern value="[0-9]{0,14}|ISENTO"/>
+			<xs:pattern value="ISENTO|[0-9]?[0-9]?[0-9]?[0-9]?[0-9]?[0-9]?[0-9]?[0-9]?[0-9]?[0-9]?[0-9]?[0-9]?[0-9]?[0-9]?|PR[0-9]{4,8}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TJust">
@@ -503,7 +503,7 @@
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
-			<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
+			<xs:pattern value="[!-ÿ]{1}[ -ÿ]*[!-ÿ]{1}|[!-ÿ]{1}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TUf">


### PR DESCRIPTION
estou alterando a  validação da inscrição estadual e string genérica pois nesse formato não valida em servidores linux, a forma que estou postando é a mesma da versão 2.0 que era compativel em servidores win e lin, e que funciona também na versão 3.0