### PR TITLE
IE opcional

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
-    "name-old": "nfephp-org/sped-cte",
-    "name": "adelio-junior/sped-cte",
+    "name": "nfephp-org/sped-cte",    
     "type": "library",
     "description": "API para geração e comunicação da CTe com as SEFAZ autorizadoras.",
     "keywords": ["cte", "sped", "nfephp"],

--- a/src/Make.php
+++ b/src/Make.php
@@ -2336,13 +2336,15 @@ class Make
                 $identificador . 'Número do CPF'
             );
         }
-        $this->dom->addChild(
-            $this->exped,
-            'IE',
-            $std->IE,
-            true,
-            $identificador . 'Inscrição Estadual'
-        );
+        if (!empty($std->IE)) {
+            $this->dom->addChild(
+                $this->exped,
+                'IE',
+                $std->IE,
+                true,
+                $identificador . 'Inscrição Estadual'
+            );
+        }
         $xNome = $std->xNome;
         if ($this->tpAmb == '2') {
             $xNome = 'CT-E EMITIDO EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL';
@@ -2504,13 +2506,15 @@ class Make
                 $identificador . 'Número do CPF'
             );
         }
-        $this->dom->addChild(
-            $this->receb,
-            'IE',
-            $std->IE,
-            true,
-            $identificador . 'Inscrição Estadual'
-        );
+        if (!empty($std->IE)) {
+            $this->dom->addChild(
+                $this->receb,
+                'IE',
+                $std->IE,
+                true,
+                $identificador . 'Inscrição Estadual'
+            );
+        }
         $xNome = $std->xNome;
         if ($this->tpAmb == '2') {
             $xNome = 'CT-E EMITIDO EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL';
@@ -2672,13 +2676,15 @@ class Make
                 $identificador . 'Número do CPF'
             );
         }
-        $this->dom->addChild(
-            $this->dest,
-            'IE',
-            $std->IE,
-            true,
-            $identificador . 'Inscrição Estadual'
-        );
+        if (!empty($std->IE)) {
+            $this->dom->addChild(
+                $this->dest,
+                'IE',
+                $std->IE,
+                true,
+                $identificador . 'Inscrição Estadual'
+            );
+        }
         $xNome = $std->xNome;
         if ($this->tpAmb == '2') {
             $xNome = 'CT-E EMITIDO EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL';


### PR DESCRIPTION
- Nos casos de Expedidor, Recebedor e Destinatário a inscrição estadual poderá ser vazia de acordo com manual. Deste modo a tag <IE/> não será criada.
- O composer.json deve indicar apenas o nome do repositório oficial nfephp-org/sped-cte no packagist, favor não renomear com forks.