### PR TITLE
Ajuste no schema geral TString

### DIFF
--- a/schemes/PL_CTe_300/tiposGeralCTe_v3.00.xsd
+++ b/schemes/PL_CTe_300/tiposGeralCTe_v3.00.xsd
@@ -504,7 +504,7 @@
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
-			<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
+			<xs:pattern value="[!-ÿ]{1}[ -ÿ]*[!-ÿ]{1}|[!-ÿ]{1}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TUf">


### PR DESCRIPTION
O pattern antigo causava problemas na validação usando o xsd pelo PHP, como por exemplo não permitir campos strings com apenas dois caracteres.