### PR TITLE
Ajuste tag ICMS UF partilha

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -3009,7 +3009,7 @@ class Make
             );
         }
 
-        if ($std->vICMSUFFim > 0 || $std->vICMSUFIni > 0) {
+        if ($std->vICMSUFFim != '' || $std->vICMSUFIni != '') {
             $icmsDifal = $this->dom->createElement("ICMSUFFim");
             $this->dom->addChild(
                 $icmsDifal,


### PR DESCRIPTION
O valor dos validadores vICMSUFFim ou vICMSUFIni podem ser zero (0.00). Porém, não podem ser vazios para criar suas reespectivas tags.
Anteriormente mesmo enviando 0 as tags não era geradas.