### PR TITLE
[UPDATE] Informações do CTEOS Complementar

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -755,8 +755,12 @@ class Make
 
             if ($this->infModal != '') {
                 $this->dom->appChild($this->infCTeNorm, $this->infModal, 'Falta tag "infModal"');
-                $this->dom->appChild($this->rodo, $this->veic, 'Falta tag "veic"');
-                $this->dom->appChild($this->infModal, $this->rodo, 'Falta tag "rodo"');
+                if(!empty($this->veic)){
+                    $this->dom->appChild($this->rodo, $this->veic, 'Falta tag "veic"');
+                }
+                if(!empty($this->rodo)){
+                    $this->dom->appChild($this->infModal, $this->rodo, 'Falta tag "rodo"');
+                }
             }
         }
         
@@ -1423,13 +1427,15 @@ class Make
                 $identificador . 'Número do CPF'
             );
         }
-        $this->dom->addChild(
-            $this->toma,
-            'IE',
-            $std->IE,
-            false,
-            $identificador . 'Inscrição Estadual'
-        );
+        if ($std->CNPJ != '' || $std->IE != '') {
+            $this->dom->addChild(
+                $this->toma,
+                'IE',
+                $std->IE,
+                false,
+                $identificador . 'Inscrição Estadual'
+            );
+        }
         $this->dom->addChild(
             $this->toma,
             'xNome',
@@ -4077,6 +4083,26 @@ class Make
         );
         return $this->infCteComp;
     }
+    /**
+     * Gera as tags para o elemento: "infCteOsComp" (Detalhamento do CT-e OS complementado)
+     * #410
+     * Nível: 1
+     * @return DOMElement|\DOMNode
+     */
+    public function taginfCTeOsComp($std)
+    {
+        $identificador = '#410 <infCteComp> - ';
+        $this->infCteComp = $this->dom->createElement('infCteComp');
+        $this->dom->addChild(
+            $this->infCteComp,
+            'chCTe',
+            $std->chave,
+            true,
+            $identificador . ' Chave do CT-e complementado'
+        );
+        return $this->infCteComp;
+    }
+    
 
     /**
      * Gera as tags para o elemento: "infCteAnu" (Detalhamento do CT-e de Anulação)


### PR DESCRIPTION
Adicionado função taginfCTeOsComp devido ao CTEOS referenciar ao campo chCTe e o CTE ao campo chave.
Adicionado parâmetros de um IF para retirar o IE (Inscrição Estadual) de pessoa fisica ou quando a IE for vazia.