### PR TITLE
Tag IE do emit pode ser vazia

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -2046,13 +2046,15 @@ class Make
             true,
             $identificador . 'CNPJ do emitente'
         );
-        $this->dom->addChild(
-            $this->emit,
-            'IE',
-            Strings::onlyNumbers($std->IE),
-            true,
-            $identificador . 'Inscrição Estadual do Emitente'
-        );
+        if( $std->IE != '' ){
+            $this->dom->addChild(
+                $this->emit,
+                'IE',
+                Strings::onlyNumbers($std->IE),
+                true,
+                $identificador . 'Inscrição Estadual do Emitente'
+            );
+        }
         $this->dom->addChild(
             $this->emit,
             'IEST',


### PR DESCRIPTION
Tag IE do emit pode ser vazia, ou seja, o Emitente pode ter a Inscrição Estadual ISENTO. Sendo assim não precisa mandar a tag... foi adicionado um IF para esconder quando o IE for ISENTO.