### PR TITLE
Correção Operação de Consulta CTe - Estados MT e PR

### DIFF
--- a/storage/wscte_3.00_mod57.xml
+++ b/storage/wscte_3.00_mod57.xml
@@ -74,7 +74,7 @@
             <CteRetRecepcao method='CTeRetRecepcao' operation='CteRetRecepcao' version='3.00'>https://cte.sefaz.mt.gov.br/ctews/services/CteRetRecepcao</CteRetRecepcao>
             <CteCancelamento method='CTeCancelamento' operation='CteCancelamento' version='3.00'>https://cte.sefaz.mt.gov.br/ctews/services/CteCancelamento</CteCancelamento>
             <CteInutilizacao method='CTeInutilizacao' operation='CteInutilizacao' version='3.00'>https://cte.sefaz.mt.gov.br/ctews/services/CteInutilizacao</CteInutilizacao>
-            <CteConsultaProtocolo method='cteConsultaCT' operation='CteConsultaProtocolo' version='3.00'>https://cte.sefaz.mt.gov.br/ctews/services/CteConsulta</CteConsultaProtocolo>
+            <CteConsultaProtocolo method='cteConsultaCT' operation='CteConsulta' version='3.00'>https://cte.sefaz.mt.gov.br/ctews/services/CteConsulta</CteConsultaProtocolo>
             <CteStatusServico method='cteStatusServicoCT' operation='CteStatusServico' version='3.00'>https://cte.sefaz.mt.gov.br/ctews/services/CteStatusServico</CteStatusServico>
             <CteRecepcaoEvento method='cteRecepcaoEvento' operation='CteRecepcaoEvento' version='3.00'>https://cte.sefaz.mt.gov.br/ctews2/services/CteRecepcaoEvento</CteRecepcaoEvento>
         </producao>
@@ -87,7 +87,7 @@
             <CteRetRecepcao method='CTeRetRecepcao' operation='CteRetRecepcao' version='3.00'>https://homologacao.cte.fazenda.pr.gov.br/cte/CteRetRecepcao?wsdl</CteRetRecepcao>
             <CteCancelamento method='CTeCancelamento' operation='CteCancelamento' version='3.00'>https://homologacao.cte.fazenda.pr.gov.br/cte/CteCancelamento?wsdl</CteCancelamento>
             <CteInutilizacao method='CTeInutilizacao' operation='CteInutilizacao' version='3.00'>https://homologacao.cte.fazenda.pr.gov.br/cte/CteInutilizacao?wsdl</CteInutilizacao>
-            <CteConsultaProtocolo method='cteConsultaCT' operation='CteConsultaProtocolo' version='3.00'>https://homologacao.cte.fazenda.pr.gov.br/cte/CteConsulta?wsdl</CteConsultaProtocolo>
+            <CteConsultaProtocolo method='cteConsultaCT' operation='CteConsulta' version='3.00'>https://homologacao.cte.fazenda.pr.gov.br/cte/CteConsulta?wsdl</CteConsultaProtocolo>
             <CteStatusServico method='cteStatusServicoCT' operation='CteStatusServico' version='3.00'>https://homologacao.cte.fazenda.pr.gov.br/cte/CteStatusServico?wsdl</CteStatusServico>
             <CteRecepcaoEvento method='cteRecepcaoEvento' operation='CteRecepcaoEvento' version='3.00'>https://homologacao.cte.fazenda.pr.gov.br/cte/CteRecepcaoEvento?wsdl</CteRecepcaoEvento>
         </homologacao>
@@ -97,7 +97,7 @@
             <CteRetRecepcao method='CTeRetRecepcao' operation='CteRetRecepcao' version='3.00'>https://cte.fazenda.pr.gov.br/cte/CteRetRecepcao?wsdl</CteRetRecepcao>
             <CteCancelamento method='CTeCancelamento' operation='CteCancelamento' version='3.00'>https://cte.fazenda.pr.gov.br/cte/CteCancelamento?wsdl</CteCancelamento>
             <CteInutilizacao method='CTeInutilizacao' operation='CteInutilizacao' version='3.00'>https://cte.fazenda.pr.gov.br/cte/CteInutilizacao?wsdl</CteInutilizacao>
-            <CteConsultaProtocolo method='cteConsultaCT' operation='CteConsultaProtocolo' version='3.00'>https://cte.fazenda.pr.gov.br/cte/CteConsulta?wsdl</CteConsultaProtocolo>
+            <CteConsultaProtocolo method='cteConsultaCT' operation='CteConsulta' version='3.00'>https://cte.fazenda.pr.gov.br/cte/CteConsulta?wsdl</CteConsultaProtocolo>
             <CteStatusServico method='cteStatusServicoCT' operation='CteStatusServico' version='3.00'>https://cte.fazenda.pr.gov.br/cte/CteStatusServico?wsdl</CteStatusServico>
             <CteRecepcaoEvento method='cteRecepcaoEvento' operation='CteRecepcaoEvento' version='3.00'>https://cte.fazenda.pr.gov.br/cte/CteRecepcaoEvento?wsdl</CteRecepcaoEvento>
         </producao>


### PR DESCRIPTION
Correção da operação para consulta de CTe nos estados do MT e PR.
Creio que o estado do MS também precise de ajuste, mas não consegui acessar o WSDL para confirmar.

No formato em que se encontra, ao consultar o status da chave nos respectivos estados, a Sefaz estava retornando o erro:
```
  <soapenv:Fault>
         <soapenv:Code>
            <soapenv:Value>soapenv:Server.userException</soapenv:Value>
         </soapenv:Code>
         <soapenv:Reason>
            <soapenv:Text xml:lang="en">	</soapenv:Text>
         </soapenv:Reason>
         <soapenv:Detail>
            <ns1:hostname xmlns:ns1="http://xml.apache.org/axis/">tapajos04.sefaz.mt.gov.br</ns1:hostname>
         </soapenv:Detail>
      </soapenv:Fault>
```

