### PR TITLE
removendo a tag tpNav do modal aquaviário

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -3554,13 +3554,6 @@ class Make
             true,
             $identificador . 'irin'
         );
-        $this->dom->addChild(
-            $this->aquav,
-            'tpNav',
-            $std->tpNav,
-            true,
-            $identificador . 'tpNav'
-        );
         return $this->aquav;
     }
 


### PR DESCRIPTION
removendo a tag tpNav do modal aquaviário conforme documentação da sefaz, a mesma não existe mais 