### PR TITLE
removendo a obrigatorieda da tag tpNav

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -3601,7 +3601,7 @@ class Make
             $this->aquav,
             'tpNav',
             $std->tpNav,
-            true,
+            false,
             $identificador . 'tpNav'
         );
         return $this->aquav;


### PR DESCRIPTION
como consta no documento http://www.cte.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=7V%20i40m98sg=
pagina 47 a tag tpNav não é obrigatória 