### PR TITLE
Remover Caracter Especial Manifesto

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -537,7 +537,7 @@ class Tools extends ToolsCommon
         if ($tpEvento == 610110) {
             $xJust = Strings::replaceSpecialsChars(substr(trim($xJust), 0, 255));
             $tagAdic = "<evPrestDesacordo>"
-                . "<descEvento>Prestação do Serviço em Desacordo</descEvento>"
+                . "<descEvento>Prestacao do Servico em Desacordo</descEvento>"
                 . "<indDesacordoOper>1</indDesacordoOper>"
                 . "<xObs>$xJust</xObs>"
                 . "</evPrestDesacordo>";


### PR DESCRIPTION
Para o estado do MT ao tentar fazer o manifesto de Prestação do Serviço em Desacordo, estava retornando a critica "402 - Rejeicao : XML da area de dados com codificacao diferente de UTF-8." da sefaz. Ao entrar em contato explicou que nao sao permitidos os caracteres especiais da $tagAdic na linha 540. Após a remoção foi manifestado corretamente.