### PR TITLE
[UPD] Pega tag raiz CTeOS quando o modelo de documento for 67.

### DIFF
--- a/src/Common/Tools.php
+++ b/src/Common/Tools.php
@@ -510,10 +510,7 @@ class Tools
         $sigla = $uf;
         if (!$ignoreContingency) {
             $contType = $this->contingency->type;
-            if (
-                !empty($contType)
-                && ($contType == 'SVRS' || $contType == 'SVSP')
-            ) {
+            if (!empty($contType) && ($contType == 'SVRS' || $contType == 'SVSP')) {
                 $sigla = $contType;
             }
         }

--- a/src/Factories/QRCode.php
+++ b/src/Factories/QRCode.php
@@ -29,8 +29,7 @@ class QRCode
     public static function putQRTag(
         \DOMDocument $dom,
         $url = ''
-    )
-    {
+    ) {
         $mod = $dom->getElementsByTagName('mod')->item(0)->nodeValue;
         # se for CTe-OS, pega a tag raiz correspondente
         if ($mod == 67) {

--- a/src/Factories/QRCode.php
+++ b/src/Factories/QRCode.php
@@ -33,7 +33,7 @@ class QRCode
     {
         $mod = $dom->getElementsByTagName('mod')->item(0)->nodeValue;
         # se for CTe-OS, pega a tag raiz correspondente
-        if($mod == 67) {
+        if ($mod == 67) {
             $cte = $dom->getElementsByTagName('CTeOS')->item(0);
         } else {
             $cte = $dom->getElementsByTagName('CTe')->item(0);

--- a/src/Factories/QRCode.php
+++ b/src/Factories/QRCode.php
@@ -31,7 +31,14 @@ class QRCode
         $url = ''
     )
     {
-        $cte = $dom->getElementsByTagName('CTe')->item(0);
+        $mod = $dom->getElementsByTagName('mod')->item(0)->nodeValue;
+        # se for CTe-OS, pega a tag raiz correspondente
+        if($mod == 67) {
+            $cte = $dom->getElementsByTagName('CTeOS')->item(0);
+        } else {
+            $cte = $dom->getElementsByTagName('CTe')->item(0);
+        }
+
         $infCte = $dom->getElementsByTagName('infCte')->item(0);
         $ide = $dom->getElementsByTagName('ide')->item(0);
         $chCTe = preg_replace('/[^0-9]/', '', $infCte->getAttribute("Id"));


### PR DESCRIPTION
O método de criação de QRCode não estava considerando XML de CTeOS, mas somente de CTe. Deste modo a busca pela tag raiz CTe retornava null, levantando erro no método $cte->insertBefore($infCTeSupl, $signature);