### PR TITLE
download de xml com cpf

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -376,7 +376,11 @@ class Tools extends ToolsCommon
         $consulta = "<distDFeInt xmlns=\"$this->urlPortal\" versao=\"$this->urlVersion\">"
             . "<tpAmb>".$this->tpAmb."</tpAmb>"
             . "<cUFAutor>$cUF</cUFAutor>"
-            . "<CNPJ>".$this->config->cnpj."</CNPJ>$tagNSU</distDFeInt>";
+            . ((strlen($this->config->cnpj)==14) ? 
+                "<CNPJ>".$this->config->cnpj."</CNPJ>" : 
+                "<CPF>".$this->config->cnpj."</CPF>"
+              )
+            . $tagNSU."</distDFeInt>";
         //valida o xml da requisição
         $this->isValid($this->urlVersion, $consulta, 'distDFeInt');
         $this->lastRequest = $consulta;
@@ -719,10 +723,11 @@ class Tools extends ToolsCommon
         $cUF = UFList::getCodeByUF($this->config->siglaUF);
         $tagChave = "<consChNFe><chNFe>$chave</chNFe></consChNFe>";
         //monta a consulta
-        $consulta = "<distDFeInt xmlns=\"$this->urlPortal\" versao=\"$this->urlVersion\">"
-            . "<tpAmb>".$this->tpAmb."</tpAmb>"
-            . "<cUFAutor>$cUF</cUFAutor>"
-            . "<CNPJ>".$this->config->cnpj."</CNPJ>$tagChave</distDFeInt>";
+            . ((strlen($this->config->cnpj)==14) ? 
+                "<CNPJ>".$this->config->cnpj."</CNPJ>" : 
+                "<CPF>".$this->config->cnpj."</CPF>"
+              )
+            . $tagChave."</distDFeInt>";
         //valida o xml da requisição
         $this->isValid($this->urlVersion, $consulta, 'distDFeInt');
         $this->lastRequest = $consulta;


### PR DESCRIPTION
O contador possuiu um certificado para seu cpf e esta autorizado na tag AutXml, portanto liberado para fazer o download dos xmls relacionados ao seu cpf, mas a api dava erro de Falha no Schema xml retornado pela sefaz, pois o mesmo nao estava preparado para receber cpf, somente cnpj, tentei manter a compatibiliadade nao trocando o nome da variavel, somente validando caso seja cpf ou cnpj, preenche o xml pela tag correta.