### PR TITLE
Update Make.php

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -5590,6 +5590,15 @@ class Make
             $this->chCTe = $chaveMontada;
         }
     }
+    
+    /**
+     * Retorna os erros detectados
+     * @return array
+     */
+    public function getErrors()
+    {
+        return $this->errors;
+    }
 
     /**
      * Includes missing or unsupported properties in stdClass


### PR DESCRIPTION
Coloquei a função getErrros() para pegar caso aja um erro na montagem do xml, como já existe no make da nfe.

e os erros já são criado pela class, apenas não tinha como pegar.

at..