### PR TITLE
Ajuste para criar a tag Entrega corretamente

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -1657,6 +1657,7 @@ class Make
             $identificador . 'Funcionário emissor do CTe'
         );
         if ($this->mod == 57) {
+            $this->tagEntrega();
             $this->dom->addChild(
                 $this->compl,
                 'origCalc',


### PR DESCRIPTION
Estava gerando a tag Entrega no lugar errado e acabava gerando erro de schema.