### PR TITLE
Correção de condicionais para inclusão do grupo idDocAntPap no XML.

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -639,15 +639,18 @@ class Make
                 $this->dom->appChild($this->infCTeNorm, $this->docAnt, 'Falta tag "docAnt"');
                 foreach ($this->emiDocAnt as $indice => $emiDocAnt) {
                     $this->dom->appChild($this->docAnt, $emiDocAnt, 'Falta tag "emiDocAnt"');
-                    $this->dom->appChild($emiDocAnt, $this->idDocAnt[$indice], 'Falta tag "idDocAnt"');
+                    $indiceIdDocant = 0;
                     if (array_key_exists($indice, $this->idDocAntEle)) {
+                        $this->dom->appChild($emiDocAnt, $this->idDocAnt[$indice][$indiceIdDocant], 'Falta tag "idDocAnt"');
                         foreach ($this->idDocAntEle[$indice] as $idDocAntEle) {
-                            $this->dom->appChild($this->idDocAnt[$indice], $idDocAntEle, 'Falta tag "emiDocAnt"');
+                            $this->dom->appChild($this->idDocAnt[$indice][$indiceIdDocant], $idDocAntEle, 'Falta tag "emiDocAnt"');
                         }
                     }
+                    if (count($this->idDocAnt[$indice]) > 1) $indiceIdDocant = $indiceIdDocant + 1;
                     if (array_key_exists($indice, $this->idDocAntPap)) {
+                        $this->dom->appChild($emiDocAnt, $this->idDocAnt[$indice][$indiceIdDocant], 'Falta tag "idDocAnt"');
                         foreach ($this->idDocAntPap[$indice] as $idDocAntPap) {
-                            $this->dom->appChild($this->idDocAnt[$indice], $idDocAntPap, 'Falta tag "idDocAntEle"');
+                            $this->dom->appChild($this->idDocAnt[$indice][$indiceIdDocant], $idDocAntPap, 'Falta tag "idDocAntEle"');
                         }
                     }
                 }
@@ -3731,7 +3734,7 @@ class Make
      */
     public function tagidDocAnt()
     {
-        $this->idDocAnt[count($this->emiDocAnt) - 1] = $this->dom->createElement('idDocAnt');
+        $this->idDocAnt[count($this->emiDocAnt) - 1][] = $this->dom->createElement('idDocAnt');
         return $this->idDocAnt;
     }
 


### PR DESCRIPTION
A função Monta(), inseria os subgrupos <idDocAntPap> e <idDocAntEle> dentro da mesma tag <idDocAnt>, o que gerava falha no schema, pois pelo  diagrama da SEFAZ, cada tag <idDocAnt> pode conter apenas 1 desses dois subgrupos.