### PR TITLE
Correção de posicionamento da tag <cobr> no CT-e OS

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -956,7 +956,7 @@ class Make
             }
         }
         if ($this->cobr != '') {
-            $this->dom->appChild($this->infCte, $this->cobr, 'Falta tag "infCte"');
+            $this->dom->appChild($this->infCTeNorm, $this->cobr, 'Falta tag "infCte"');
         }
         foreach ($this->autXML as $autXML) {
             $this->dom->appChild($this->infCte, $autXML, 'Falta tag "infCte"');


### PR DESCRIPTION
A tag <cobr> estava sendo posicionada dentro da tag <infCte>, e o correto é a tag <infCTeNorm>