### PR TITLE
adiciona tag 'cteRecepcaoLoteResult' na rootTagList

### DIFF
--- a/src/Common/Standardize.php
+++ b/src/Common/Standardize.php
@@ -59,6 +59,7 @@ class Standardize
         'CTeOS',
         'eventoCTe',
         'evCancCTe',
+        'cteRecepcaoLoteResult',
         'protCTe'
     ];
 


### PR DESCRIPTION
o serviço CteRetRecepcao da Sefaz MG retorna um xml com a tag cteRecepcaoLoteResult, porém ela não está presente na rootTagList da classe Standardize, o que gera uma DocumentException::wrongDocument(7) ao instanciar essa classe passando como parâmetro o xml retornado.

Exemplo de xml retornado pelo serviço:
`<?xml version='1.0' encoding='UTF-8'?>
<S:Envelope xmlns:S="http://www.w3.org/2003/05/soap-envelope">
    <S:Header>
        <cteCabecMsg xmlns="http://www.portalfiscal.inf.br/cte/wsdl/CteRecepcao">
            <cUF>31</cUF>
            <versaoDados>3.00</versaoDados>
        </cteCabecMsg>
    </S:Header>
    <S:Body>
        <cteRecepcaoLoteResult xmlns="http://www.portalfiscal.inf.br/cte/wsdl/CteRecepcao">
            <retEnviCTe xmlns="http://www.portalfiscal.inf.br/cte" versao="3.00">
                <tpAmb>2</tpAmb>
                <cUF>31</cUF>
                <verAplic>W-5.0.0</verAplic>
                <cStat>103</cStat>
                <xMotivo>Lote recebido com sucesso</xMotivo>
                <infRec>
                    <nRec>311000133397499</nRec>
                    <dhRecbto>2023-06-16T20:00:47-03:00</dhRecbto>
                    <tMed>0</tMed>
                </infRec>
            </retEnviCTe>
        </cteRecepcaoLoteResult>
    </S:Body>
</S:Envelope>`