### PR TITLE
Correção para tag de substituição, rejeição nas tag de infCTeNorm e infCteComp

### DIFF
--- a/src/MakeCTe.php
+++ b/src/MakeCTe.php
@@ -520,9 +520,9 @@ class MakeCTe
         }
         $this->dom->appChild($this->infCte, $this->vPrest, 'Falta tag "infCte"');
         $this->dom->appChild($this->infCte, $this->imp, 'Falta tag "imp"');
-        if ($this->tpCTe == 3 and !empty($this->infCteComp)) { // Caso seja um CTe tipo complemento de valores
+        if ($this->tpCTe == 1 and !empty($this->infCteComp)) { // Caso seja um CTe tipo complemento de valores
             $this->dom->appChild($this->infCte, $this->infCteComp, 'Falta tag "infCteComp"');
-        } elseif (in_array($this->tpCTe, [0, 1]) and !empty($this->infCTeNorm)) { // Caso seja um CTe tipo normal
+        } elseif (in_array($this->tpCTe, [0, 3]) and !empty($this->infCTeNorm)) { // Caso seja um CTe tipo normal
             $this->dom->appChild($this->infCte, $this->infCTeNorm, 'Falta tag "infCTeNorm"');
             $this->dom->appChild($this->infCTeNorm, $this->infCarga, 'Falta tag "infCarga"');
             foreach ($this->infQ as $infQ) {
@@ -645,7 +645,7 @@ class MakeCTe
             if (!empty($this->cobr)) {
                 $this->dom->appChild($this->infCTeNorm, $this->cobr, 'Falta tag "infCte"');
             }
-            if ($this->tpCTe == 1 and !empty($this->infCteSub)) {
+            if ($this->tpCTe == 3 and !empty($this->infCteSub)) {
                 $this->dom->appChild($this->infCTeNorm, $this->infCteSub, 'Falta tag "infCteSub"');
             }
             if (!empty($this->infGlobalizado)) {

--- a/storage/wscte_4.00_mod57.xml
+++ b/storage/wscte_4.00_mod57.xml
@@ -12,7 +12,7 @@
     <UF>
         <sigla>MG</sigla>
         <homologacao>
-            <CteRecepcao method='cteRecepcao' operation='CTeRecepcaoSincV4' version='4.00'>	https://hcte.fazenda.mg.gov.br/cte/services/CTeRecepcaoSincV4</CteRecepcao>
+            <CteRecepcao method='cteRecepcao' operation='CTeRecepcaoSincV4' version='4.00'>https://hcte.fazenda.mg.gov.br/cte/services/CTeRecepcaoSincV4</CteRecepcao>
             <CteConsultaProtocolo method='cteConsultaCT' operation='CTeConsultaV4' version='4.00'>https://hcte.fazenda.mg.gov.br/cte/services/CTeConsultaV4</CteConsultaProtocolo>
             <CteStatusServico method='cteStatusServicoCT' operation='CTeStatusServicoV4' version='4.00'>https://hcte.fazenda.mg.gov.br/cte/services/CTeStatusServicoV4</CteStatusServico>
             <CteRecepcaoEvento method='cteRecepcaoEvento' operation='CTeRecepcaoEventoV4' version='4.00'>https://hcte.fazenda.mg.gov.br/cte/services/CTeRecepcaoEventoV4</CteRecepcaoEvento>


### PR DESCRIPTION
Para envio de CT-e substituição e complemento, ocorre a seguinte rejeição:
Expected is one of ( {http://www.portalfiscal.inf.br/cte}infCTeNorm, {http://www.portalfiscal.inf.br/cte}infCteComp ).
505 - Rejeicao : Grupo CTe de substituicao nao informado para o CT-e substituicao.

Verifiquei que na função **monta** do **MakeCTe.php**, para criar a tag **infCteComp**, está verificando se o **tpCTe** é **3** – substituição, porem o correto é **1** – complemento. 
Ainda para criar a tag **infCTeNorm**, está verificando se o **tpCTe** é **0** – normal ou **1** – complemento, correto é os **0** – normal e **3** – substituição.
Na montagem da tag **infCteSub** está verificando o **tpCTe** é **1** – complemento, sendo o correto o **3** – substituição

Foi removido um espaço em branco na URL de homologação da sigla MG Recepcão, que gerava um erro no envio do CTe.

Desde já agradeço a atenção e fico no aguardo.
@cleitonperin 
