### PR TITLE
fix: move tag vCargaAverb da tag infQ para a tag  infCarga

### DIFF
--- a/src/MakeCTe.php
+++ b/src/MakeCTe.php
@@ -3128,7 +3128,8 @@ class MakeCTe
         $possible = [
             'vCarga',
             'proPred',
-            'xOutCat'
+            'xOutCat',
+            'vCargaAverb'
         ];
         $std = $this->equilizeParameters($std, $possible);
         $identificador = '#242 <infCarga> - ';
@@ -3154,6 +3155,13 @@ class MakeCTe
             false,
             $identificador . 'Outras Caract. da Carga'
         );
+        $this->dom->addChild(
+            $this->infCarga,
+            'vCargaAverb',
+            $this->conditionalNumberFormatting($std->vCargaAverb, 2),
+            false,
+            $identificador . 'Valor da Carga para efeito de averbação'
+        );
         return $this->infCarga;
     }
 
@@ -3170,8 +3178,7 @@ class MakeCTe
         $possible = [
             'cUnid',
             'tpMed',
-            'qCarga',
-            'vCargaAverb'
+            'qCarga'
         ];
         $std = $this->equilizeParameters($std, $possible);
         $identificador = '#257 <infQ> - ';
@@ -3197,14 +3204,7 @@ class MakeCTe
             $this->conditionalNumberFormatting($std->qCarga, 4),
             true,
             $identificador . 'Quantidade'
-        );
-        $this->dom->addChild(
-            $this->infQ[$posicao],
-            'vCargaAverb',
-            $this->conditionalNumberFormatting($std->vCargaAverb, 2),
-            false,
-            $identificador . 'Valor da Carga para efeito de averbação'
-        );
+        );       
         return $this->infQ[$posicao];
     }
 


### PR DESCRIPTION
Percebi que a tag vCargaAverb estava sendo gerada dentro do bloco infQ, quando deveria ser gerada no bloco infCarga.
Fiz o ajuste para gerar no local certo.