### PR TITLE
Informando grupo infCteSub no CT-e OS de Substituição

### DIFF
--- a/src/MakeCTeOS.php
+++ b/src/MakeCTeOS.php
@@ -303,6 +303,9 @@ class MakeCTeOS
                 $this->dom->appChild($this->rodo, $this->infFretamento, 'Falta tag "infFretamento"');
                 $this->dom->appChild($this->infModal, $this->rodo, 'Falta tag "rodo"');
             }
+            if(!empty($this->infCteSub)){ // Caso seja um CT-e OS tipo substituição
+                $this->dom->appChild($this->infCTeNorm, $this->infCteSub, 'Falta tag "infCteSub"');
+            }
         }
         if (!empty($this->cobr)) {
             $this->dom->appChild($this->infCTeNorm, $this->cobr, 'Falta tag "cobr"');


### PR DESCRIPTION
Ola, 
Verifiquei que ao enviar um **CT-e OS** com **Tipo 3 – substituição**, o grupo “**infCteSub**” não estava sendo criado no XML. Para correção foi modificado “**MakeCTeOS.php**” incluindo o grupo em questão como filho do grupo “**infCTeNorm**”. 

A falta deste grupo gera a rejeição: _505 - Rejeição: Grupo CT-e de Substituição não informado para o CT-e de Substituição_

Após a modificação, consegui autorizar alguns CT-e OS em homologação com estado **GO**, no estado de **MG** até a data está com problema para receber este tipo de CT-e OS. 

@cleitonperin 
