### PR TITLE
Adicionando evento de Cancelamento de Prestação de Serviço em Desacordo

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -356,6 +356,12 @@ class Tools extends ToolsCommon
                 . "<xObs>$xJust</xObs>"
                 . "</evPrestDesacordo>";
         }
+        if ($tpEvento == 610111) {
+            $tagAdic = "<evCancPrestDesacordo>"
+                . "<descEvento>Cancelamento Prestacao do Servico em Desacordo</descEvento>"
+                . "<nProtEvPrestDes>$xJust</nProtEvPrestDes>"
+                . "</evCancPrestDesacordo>";
+        }
         return $this->sefazEvento(
             $ufEvento,
             $chNFe,


### PR DESCRIPTION
Conforme manual do CT-e 4.00:

![image](https://github.com/nfephp-org/sped-cte/assets/18463395/7b9ede59-9fda-4ff7-8275-d590c3c5ee2d)

Foi adicionado o trecho do evento de cancelamento da Prestação de Serviço em Descordo.
Os testes foram realizados para as UFs MS e MT.

Para não ser necessário incluir um novo parâmetro na sefazManifesta, o número do protocolo do evento foi enviado na xJust.