### PR TITLE
MakeCTe - MT

### DIFF
--- a/src/MakeCTe.php
+++ b/src/MakeCTe.php
@@ -1885,7 +1885,7 @@ class MakeCTe
             $identificador . 'Sigla da UF'
         );
         if (in_array($std->UF, ['MT'])) {
-            $this->cteHomologacao = 'CT-E EMITIDO EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL';
+            $this->cteHomologacao = 'CTE EMITIDO EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL';
         }
         $this->dom->addChild(
             $this->enderEmit,


### PR DESCRIPTION
**xMotivo:**  646 -  Rejeicao :  CT-e emitido em ambiente de homologacao com Razao Social do remetente diferente de CTE EMITIDO EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL.
Segue a baixo a CTe.
[CTe MT.txt](https://github.com/nfephp-org/sped-cte/files/14538686/CTe.MT.txt)
