### PR TITLE
 MakeCTe - MT

### DIFF
--- a/src/MakeCTe.php
+++ b/src/MakeCTe.php
@@ -1884,9 +1884,7 @@ class MakeCTe
             true,
             $identificador . 'Sigla da UF'
         );
-        if (in_array($std->UF, ['MT'])) {
-            $this->cteHomologacao = 'CT-E EMITIDO EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL';
-        }
+
         $this->dom->addChild(
             $this->enderEmit,
             'fone',


### PR DESCRIPTION
**xMotivo:** 646 -  Rejeicao :  CT-e emitido em ambiente de homologacao com Razao Social do remetente diferente de CTE EMITIDO EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL.
**Solução:** Remoção de tratamento de homologação para MT.
**Resultado:** Autorizado o Uso do CT-e
[CTe MT.txt](https://github.com/nfephp-org/sped-cte/files/14538749/CTe.MT.txt)
