### PR TITLE
feat: Adiciona a nova URL do QrCode do CTe de MG

### DIFF
--- a/storage/wscte_4.00_mod57.xml
+++ b/storage/wscte_4.00_mod57.xml
@@ -17,7 +17,7 @@
             <CteConsultaProtocolo method='cteConsultaCT' operation='CTeConsultaV4' version='4.00'>https://hcte.fazenda.mg.gov.br/cte/services/CTeConsultaV4</CteConsultaProtocolo>
             <CteStatusServico method='cteStatusServicoCT' operation='CTeStatusServicoV4' version='4.00'>https://hcte.fazenda.mg.gov.br/cte/services/CTeStatusServicoV4</CteStatusServico>
             <CteRecepcaoEvento method='cteRecepcaoEvento' operation='CTeRecepcaoEventoV4' version='4.00'>https://hcte.fazenda.mg.gov.br/cte/services/CTeRecepcaoEventoV4</CteRecepcaoEvento>
-            <QRCode method='QRCode' operation='QRCode' version='4.00'>https://cte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml</QRCode>
+            <QRCode method='QRCode' operation='QRCode' version='4.00'>https://portalcte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml</QRCode>
         </homologacao>
         <producao>
             <CteRecepcao method='cteRecepcao' operation='CTeRecepcaoSincV4' version='4.00'>https://cte.fazenda.mg.gov.br/cte/services/CTeRecepcaoSincV4</CteRecepcao>
@@ -25,7 +25,7 @@
             <CteConsultaProtocolo method='cteConsultaCT' operation='CTeConsultaV4' version='4.00'>https://cte.fazenda.mg.gov.br/cte/services/CTeConsultaV4</CteConsultaProtocolo>
             <CteStatusServico method='cteStatusServicoCT' operation='CTeStatusServicoV4' version='4.00'>https://cte.fazenda.mg.gov.br/cte/services/CTeStatusServicoV4</CteStatusServico>
             <CteRecepcaoEvento method='cteRecepcaoEvento' operation='CTeRecepcaoEventoV4' version='4.00'>https://cte.fazenda.mg.gov.br/cte/services/CTeRecepcaoEventoV4</CteRecepcaoEvento>
-            <QRCode method='QRCode' operation='QRCode' version='4.00'>https://cte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml</QRCode>
+            <QRCode method='QRCode' operation='QRCode' version='4.00'>https://portalcte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml</QRCode>
         </producao>
     </UF>
     <UF>

--- a/storage/wscte_4.00_mod64.xml
+++ b/storage/wscte_4.00_mod64.xml
@@ -16,14 +16,14 @@
             <CteConsultaProtocolo method='cteConsultaCT' operation='CTeConsultaV4' version='4.00'>https://hcte.fazenda.mg.gov.br/cte/services/CTeConsultaV4</CteConsultaProtocolo>
             <CteStatusServico method='cteStatusServicoCT' operation='CTeStatusServicoV4' version='4.00'>https://hcte.fazenda.mg.gov.br/cte/services/CTeStatusServicoV4</CteStatusServico>
             <CteRecepcaoEvento method='cteRecepcaoEvento' operation='CTeRecepcaoEventoV4' version='4.00'>https://hcte.fazenda.mg.gov.br/cte/services/CTeRecepcaoEventoV4</CteRecepcaoEvento>
-            <QRCode method='QRCode' operation='QRCode' version='4.00'>https://cte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml</QRCode>
+            <QRCode method='QRCode' operation='QRCode' version='4.00'>https://portalcte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml</QRCode>
         </homologacao>
         <producao>
             <CteRecepcao method='cteRecepcao' operation='CTeRecepcaoGTVeV4' version='4.00'>https://cte.fazenda.mg.gov.br/cte/services/CTeRecepcaoGTVeV4</CteRecepcao>
             <CteConsultaProtocolo method='cteConsultaCT' operation='CTeConsultaV4' version='4.00'>https://cte.fazenda.mg.gov.br/cte/services/CTeConsultaV4</CteConsultaProtocolo>
             <CteStatusServico method='cteStatusServicoCT' operation='CTeStatusServicoV4' version='4.00'>https://cte.fazenda.mg.gov.br/cte/services/CTeStatusServicoV4</CteStatusServico>
             <CteRecepcaoEvento method='cteRecepcaoEvento' operation='CTeRecepcaoEventoV4' version='4.00'>https://cte.fazenda.mg.gov.br/cte/services/CTeRecepcaoEventoV4</CteRecepcaoEvento>
-            <QRCode method='QRCode' operation='QRCode' version='4.00'>https://cte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml</QRCode>
+            <QRCode method='QRCode' operation='QRCode' version='4.00'>https://portalcte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml</QRCode>
         </producao>
     </UF>
     <UF>
@@ -88,9 +88,9 @@
         </homologacao>
         <producao>
             <CteRecepcao method='cteRecepcao' operation='CTeRecepcaoGTVeV4' version='4.00'>https://cte.svrs.rs.gov.br/ws/CTeRecepcaoGTVeV4/CTeRecepcaoGTVeV4.asmx</CteRecepcao>
-            <CteConsultaProtocolo method='cteConsultaCT' operation='CTeConsultaV4' version='4.00'>	https://cte.svrs.rs.gov.br/ws/CTeConsultaV4/CTeConsultaV4.asmx</CteConsultaProtocolo>
+            <CteConsultaProtocolo method='cteConsultaCT' operation='CTeConsultaV4' version='4.00'>https://cte.svrs.rs.gov.br/ws/CTeConsultaV4/CTeConsultaV4.asmx</CteConsultaProtocolo>
             <CteStatusServico method='cteStatusServicoCT' operation='CTeStatusServicoV4' version='4.00'>https://cte.svrs.rs.gov.br/ws/CTeStatusServicoV4/CTeStatusServicoV4.asmx</CteStatusServico>
-            <CteRecepcaoEvento method='cteRecepcaoEvento' operation='CTeRecepcaoEventoV4' version='4.00'>	https://cte.svrs.rs.gov.br/ws/CTeRecepcaoEventoV4/CTeRecepcaoEventoV4.asmx</CteRecepcaoEvento>
+            <CteRecepcaoEvento method='cteRecepcaoEvento' operation='CTeRecepcaoEventoV4' version='4.00'>https://cte.svrs.rs.gov.br/ws/CTeRecepcaoEventoV4/CTeRecepcaoEventoV4.asmx</CteRecepcaoEvento>
             <QRCode method='QRCode' operation='QRCode' version='4.00'>https://dfe-portal.svrs.rs.gov.br/cte/qrCode</QRCode>
         </producao>
     </UF>
@@ -122,9 +122,9 @@
         </homologacao>
         <producao>
             <CteRecepcao method='cteRecepcao' operation='CTeRecepcaoGTVeV4' version='4.00'>https://cte.svrs.rs.gov.br/ws/CTeRecepcaoGTVeV4/CTeRecepcaoGTVeV4.asmx</CteRecepcao>
-            <CteConsultaProtocolo method='cteConsultaCT' operation='CTeConsultaV4' version='4.00'>	https://cte.svrs.rs.gov.br/ws/CTeConsultaV4/CTeConsultaV4.asmx</CteConsultaProtocolo>
+            <CteConsultaProtocolo method='cteConsultaCT' operation='CTeConsultaV4' version='4.00'>https://cte.svrs.rs.gov.br/ws/CTeConsultaV4/CTeConsultaV4.asmx</CteConsultaProtocolo>
             <CteStatusServico method='cteStatusServicoCT' operation='CTeStatusServicoV4' version='4.00'>https://cte.svrs.rs.gov.br/ws/CTeStatusServicoV4/CTeStatusServicoV4.asmx</CteStatusServico>
-            <CteRecepcaoEvento method='cteRecepcaoEvento' operation='CTeRecepcaoEventoV4' version='4.00'>	https://cte.svrs.rs.gov.br/ws/CTeRecepcaoEventoV4/CTeRecepcaoEventoV4.asmx</CteRecepcaoEvento>
+            <CteRecepcaoEvento method='cteRecepcaoEvento' operation='CTeRecepcaoEventoV4' version='4.00'>https://cte.svrs.rs.gov.br/ws/CTeRecepcaoEventoV4/CTeRecepcaoEventoV4.asmx</CteRecepcaoEvento>
             <QRCode method='QRCode' operation='QRCode' version='4.00'>https://dfe-portal.svrs.rs.gov.br/cte/qrCode</QRCode>
         </producao>
     </UF>

--- a/storage/wscte_4.00_mod67.xml
+++ b/storage/wscte_4.00_mod67.xml
@@ -16,14 +16,14 @@
             <CteConsultaProtocolo method='cteConsultaCT' operation='CTeConsultaV4' version='4.00'>https://hcte.fazenda.mg.gov.br/cte/services/CTeConsultaV4</CteConsultaProtocolo>
             <CteStatusServico method='cteStatusServicoCT' operation='CTeStatusServicoV4' version='4.00'>https://hcte.fazenda.mg.gov.br/cte/services/CTeStatusServicoV4</CteStatusServico>
             <CteRecepcaoEvento method='cteRecepcaoEvento' operation='CTeRecepcaoEventoV4' version='4.00'>https://hcte.fazenda.mg.gov.br/cte/services/CTeRecepcaoEventoV4</CteRecepcaoEvento>
-            <QRCode method='QRCode' operation='QRCode' version='4.00'>https://cte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml</QRCode>
+            <QRCode method='QRCode' operation='QRCode' version='4.00'>https://portalcte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml</QRCode>
         </homologacao>
         <producao>
             <CteRecepcao method='cteRecepcaoOS' operation='CTeRecepcaoOSV4' version='4.00'>https://cte.fazenda.mg.gov.br/cte/services/CTeRecepcaoOSV4</CteRecepcao>
             <CteConsultaProtocolo method='cteConsultaCT' operation='CTeConsultaV4' version='4.00'>https://cte.fazenda.mg.gov.br/cte/services/CTeConsultaV4</CteConsultaProtocolo>
             <CteStatusServico method='cteStatusServicoCT' operation='CTeStatusServicoV4' version='4.00'>https://cte.fazenda.mg.gov.br/cte/services/CTeStatusServicoV4</CteStatusServico>
             <CteRecepcaoEvento method='cteRecepcaoEvento' operation='CTeRecepcaoEventoV4' version='4.00'>https://cte.fazenda.mg.gov.br/cte/services/CTeRecepcaoEventoV4</CteRecepcaoEvento>
-            <QRCode method='QRCode' operation='QRCode' version='4.00'>https://cte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml</QRCode>
+            <QRCode method='QRCode' operation='QRCode' version='4.00'>https://portalcte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml</QRCode>
         </producao>
     </UF>
     <UF>


### PR DESCRIPTION
Comunicado da Sefaz de MG

> Por motivos técnicos, a partir do dia 24/04/2025, a URL do QrCode do CTe será modificada. De hoje até dia 23/04/2025, a SEF-MG aceitará tanto a URL antiga quanto a nova. De 24/04/2025 em diante, apenas a URL nova será aceita, conforme descrito abaixo:
> 
> CTe (caminho: CTe -> infCTeSupl -> infCTeSupl):  
>   Url antiga: https://cte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml
>   Url nova: https://portalcte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml
> 
> Gentileza atentar-se ao prazo limite, pois após 23/04/2025 as URLs antigas não serão mais aceitas.

@cleitonperin @robmachado Poderiam verificar, por favor?