### PR TITLE
feat: Reforma tributária 2025.001 - v1.10 - CTe Simplificado

### DIFF
--- a/src/MakeCTe.php
+++ b/src/MakeCTe.php
@@ -5119,6 +5119,7 @@ class MakeCTe
         $possible = [
             'CST',
             'cClassTrib',
+            'indDoacao', // opcional Indicador de Doação
             'vBC',
             //dados IBS Estadual
             'gIBSUF_pIBSUF', //opcional Alíquota do IBS de competência das UF 3v2-4, OBRIGATÓRIO se vBC for informado
@@ -5169,6 +5170,13 @@ class MakeCTe
             $std->cClassTrib,
             true,
             "$identificador Código de Classificação Tributária do IBS e CBS (cClassTrib)"
+        );
+        $this->dom->addChild(
+            $ibscbs,
+            'indDoacao',
+            $std->indDoacao,
+            false,
+            "$identificador Indicador de Doação (indDoacao)"
         );
         //gIBSCBS é opcional e também é um choice com IBSCBSMono
         if (!is_null($std->vBC) && is_numeric($std->vBC)) {
@@ -5487,7 +5495,7 @@ class MakeCTe
     }
 
     /**
-     * Tipo Estorno de Crédito UB116 pai UB12
+     * Estorno de Crédito UB116 pai UB12
      * @param stdClass $std
      * @return DOMElement
      * @throws DOMException

--- a/src/MakeCTeSimp.php
+++ b/src/MakeCTeSimp.php
@@ -3606,6 +3606,7 @@ class MakeCTeSimp
         $possible = [
             'CST',
             'cClassTrib',
+            'indDoacao', // opcional Indicador de Doação
             'vBC',
             //dados IBS Estadual
             'gIBSUF_pIBSUF', //opcional Alíquota do IBS de competência das UF 3v2-4, OBRIGATÓRIO se vBC for informado
@@ -3654,6 +3655,13 @@ class MakeCTeSimp
             $std->cClassTrib,
             true,
             "$identificador Código de Classificação Tributária do IBS e CBS (cClassTrib)"
+        );
+        $this->dom->addChild(
+            $ibscbs,
+            'indDoacao',
+            $std->indDoacao,
+            false,
+            "$identificador Indicador de Doação (indDoacao)"
         );
         //gIBSCBS é opcional e também é um choice com IBSCBSMono
         if (!empty($std->vBC)) {
@@ -3969,7 +3977,7 @@ class MakeCTeSimp
     }
 
     /**
-     * Tipo Estorno de Crédito UB116 pai UB12
+     * Estorno de Crédito UB116 pai UB12
      * @param stdClass $std
      * @return DOMElement
      * @throws DOMException


### PR DESCRIPTION
Nota Técnica 2025.001 - RTC - v1.10

Exclusão do grupo de informações do crédito presumido por não se aplicar aos cClassTrib associados ao DFe
Criação do indicador de doação e do grupo de Estorno de crédito vinculado a um novo indicador na tabela cClassTrib para esta finalidade

Implementei para o CTe normal e acabei esquecendo de implementar no CTe Simplificado.

@cleitonperin @robmachado