### PR TITLE
Mudança na tag vTotDFe

### DIFF
--- a/src/MakeCTe.php
+++ b/src/MakeCTe.php
@@ -2821,7 +2821,6 @@ class MakeCTe
             'vICMSUFIni',
             'vICMSDeson',
             'cBenef',
-            'vTotDFe',
         ];
         $std = $this->equilizeParameters($std, $possible);
         $identificador = 'N01 <ICMSxx> - ';
@@ -3259,12 +3258,25 @@ class MakeCTe
             );
             $this->ICMSUFFim = $icmsDifal;
         }
-
-        if (!empty($std->vTotDFe)) {
-            $this->vTotDFe = $this->dom->createElement("vTotDFe", $this->conditionalNumberFormatting($std->vTotDFe));
-        }
-
         return $this->ICMS;
+    }
+
+    /**
+     * tagVTotDFe
+     * Valor total do documento fiscal (vTPrest + total do IBS + total da CBS) 
+     *
+     * @return DOMElement
+     */
+    public function tagVTotDFe($std)
+    {
+        $possible = [
+            'vTotDFe',
+        ];
+        $std = $this->equilizeParameters($std, $possible);
+
+        $this->vTotDFe = $this->dom->createElement("vTotDFe", $this->conditionalNumberFormatting($std->vTotDFe));
+
+        return $this->vTotDFe;
     }
 
     /**


### PR DESCRIPTION
Boa tarde,
hoje, 23/12/2025, saiu a nova versão da[ nota técnica da RTC (v1.12)](https://dfe-portal.svrs.rs.gov.br/CTE/DownloadArquivoEstatico/?sistema=CTE&tipoArquivo=3&nomeArquivo=CTe_Nota_Tecnica_2025_001_RTC_v1.12.pdf).

O estado do PR prontamente implementou as alterações e os CTes começaram a ser rejeitados com a seguinte rejeição:
**365 - Total do DFe inválido**

A rejeição ocorre em todos os regimes tributários pela ausência da tag `vTotDFe` no grupo `imp`, já que essa tag é independente do IBS/CBS.

Atualmente, a biblioteca só preenche o vTotDFe quando as tags de IBS/CBS são informadas, o que causa rejeição para quem não utiliza a reforma tributária.

Proponho alterar essa implementação para que o `vTotDFe` seja preenchido de forma independente das tags de IBS/CBS. Para isso, ele deixaria de ser tratado dentro da função `tagIBSCBS` e passaria a ter uma função própria, evitando rejeições em cenários sem IBS/CBS.

```` // Valor total do DFe
$vTotDfe = new stdClass();
$vTotDfe->vTotDFe = $vPrest->vTPrest;
$makeCte->tagvTotDfe($vTotDfe);
````

@cleitonperin @robmachado 