### PR TITLE
Correção na geração da tag "vTotDFe" no CTe Simp.

### DIFF
--- a/src/MakeCTeSimp.php
+++ b/src/MakeCTeSimp.php
@@ -1508,15 +1508,13 @@ class MakeCTeSimp
             true,
             $identificador . 'Valor a Receber'
         );
-        if ($std->vTotDFe > 0) {
-            $this->dom->addChild(
-                $this->total,
-                'vTotDFe',
-                $this->conditionalNumberFormatting($std->vTotDFe),
-                true,
-                $identificador . 'Valor total a Receber'
-            );
-        }
+        $this->dom->addChild(
+            $this->total,
+            'vTotDFe',
+            $this->conditionalNumberFormatting($std->vTotDFe),
+            true,
+            $identificador . 'Valor total a Receber'
+        );
         return $this->total;
     }
 


### PR DESCRIPTION
Para evitar o erro 360 - Rejeição: "Total do DFe de preenchimento obrigatório", removemos a restrição que exigia a criação da tag vTotDFe apenas quando seu valor era superior a zero. Segundo a Nota Técnica CTe_Nota_Tecnica_2025_001_RTC_v1.13, essa tag é, de fato, obrigatória.

<img width="733" height="215" alt="image" src="https://github.com/user-attachments/assets/4e1b31e4-0b3c-40bd-a530-d67427f3194c" />
