### PR TITLE
fix: suporte a CNPJ alfanumerico na extracao de chave de acesso do CT-e

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php" : ">=7.0",
-        "nfephp-org/sped-common" : "^5.0",
+        "nfephp-org/sped-common" : "^5.1.17",
         "justinrainbow/json-schema": "^5.2",
         "ext-zlib": "*",
         "ext-dom": "*",

--- a/src/Complements.php
+++ b/src/Complements.php
@@ -2,6 +2,7 @@
 
 namespace NFePHP\CTe;
 
+use NFePHP\Common\Keys;
 use NFePHP\Common\Strings;
 use NFePHP\CTe\Common\Standardize;
 use NFePHP\CTe\Exception\DocumentsException;
@@ -122,7 +123,7 @@ class Complements
         $cte = $req->getElementsByTagName('CTe')->item(0);
         $infCTe = $req->getElementsByTagName('infCte')->item(0);
         $versao = $infCTe->getAttribute("versao");
-        $chave = preg_replace('/[^0-9]/', '', $infCTe->getAttribute("Id"));
+        $chave = Keys::extractAccessKey($infCTe->getAttribute("Id"));
         $digCTe = $req->getElementsByTagName('DigestValue')
             ->item(0)
             ->nodeValue;
@@ -180,7 +181,7 @@ class Complements
         $cte = $req->getElementsByTagName('CTeSimp')->item(0);
         $infCTe = $req->getElementsByTagName('infCte')->item(0);
         $versao = $infCTe->getAttribute("versao");
-        $chave = preg_replace('/[^0-9]/', '', $infCTe->getAttribute("Id"));
+        $chave = Keys::extractAccessKey($infCTe->getAttribute("Id"));
         $digCTe = $req->getElementsByTagName('DigestValue')
             ->item(0)
             ->nodeValue;
@@ -238,7 +239,7 @@ class Complements
         $cte = $req->getElementsByTagName('CTeOS')->item(0);
         $infCTe = $req->getElementsByTagName('infCte')->item(0);
         $versao = $infCTe->getAttribute("versao");
-        $chave = preg_replace('/[^0-9]/', '', $infCTe->getAttribute("Id"));
+        $chave = Keys::extractAccessKey($infCTe->getAttribute("Id"));
         $digCTe = $req->getElementsByTagName('DigestValue')
             ->item(0)
             ->nodeValue;

--- a/src/Factories/QRCode.php
+++ b/src/Factories/QRCode.php
@@ -17,6 +17,7 @@ namespace NFePHP\CTe\Factories;
 
 use DOMDocument;
 use NFePHP\Common\Certificate;
+use NFePHP\Common\Keys;
 
 class QRCode
 {
@@ -48,7 +49,7 @@ class QRCode
         }
         $infCte = $dom->getElementsByTagName('infCte')->item(0);
         $ide = $dom->getElementsByTagName('ide')->item(0);
-        $chCTe = preg_replace('/[^0-9]/', '', $infCte->getAttribute("Id"));
+        $chCTe = Keys::extractAccessKey($infCte->getAttribute("Id"));
         $tpAmb = $ide->getElementsByTagName('tpAmb')->item(0)->nodeValue;
         $tpEmis = $ide->getElementsByTagName('tpEmis')->item(0)->nodeValue;
         $sign = '';

--- a/src/MakeCTe.php
+++ b/src/MakeCTe.php
@@ -911,7 +911,7 @@ class MakeCTe
      */
     public function taginfCTe($std)
     {
-        $chave = preg_replace('/[^0-9]/', '', $std->Id);
+        $chave = Keys::extractAccessKey($std->Id);
         $this->infCte = $this->dom->createElement('infCte');
         $this->infCte->setAttribute('Id', 'CTe' . $chave);
         $this->infCte->setAttribute('versao', $std->versao);
@@ -5786,7 +5786,7 @@ class MakeCTe
         $nNF = $ide->getElementsByTagName('nCT')->item(0)->nodeValue;
         $tpEmis = $ide->getElementsByTagName('tpEmis')->item(0)->nodeValue;
         $cCT = $ide->getElementsByTagName('cCT')->item(0)->nodeValue;
-        $chave = str_replace('CTe', '', $infCTe->getAttribute("Id"));
+        $chave = Keys::extractAccessKey($infCTe->getAttribute("Id"));
 
         $dt = new \DateTime($dhEmi);
 

--- a/src/MakeCTeOS.php
+++ b/src/MakeCTeOS.php
@@ -472,7 +472,7 @@ class MakeCTeOS
      */
     public function taginfCTe($std)
     {
-        $chave = preg_replace('/[^0-9]/', '', $std->Id);
+        $chave = Keys::extractAccessKey($std->Id);
         $this->infCte = $this->dom->createElement('infCte');
         $this->infCte->setAttribute('Id', 'CTe' . $chave);
         $this->infCte->setAttribute('versao', $std->versao);
@@ -3091,7 +3091,7 @@ class MakeCTeOS
         $nNF = $ide->getElementsByTagName('nCT')->item(0)->nodeValue;
         $tpEmis = $ide->getElementsByTagName('tpEmis')->item(0)->nodeValue;
         $cCT = $ide->getElementsByTagName('cCT')->item(0)->nodeValue;
-        $chave = str_replace('CTe', '', $infCTe->getAttribute("Id"));
+        $chave = Keys::extractAccessKey($infCTe->getAttribute("Id"));
 
         $dt = new \DateTime($dhEmi);
 

--- a/src/MakeCTeSimp.php
+++ b/src/MakeCTeSimp.php
@@ -713,7 +713,7 @@ class MakeCTeSimp
      */
     public function taginfCTe($std)
     {
-        $chave = preg_replace('/[^0-9]/', '', $std->Id);
+        $chave = Keys::extractAccessKey($std->Id);
         $this->infCte = $this->dom->createElement('infCte');
         $this->infCte->setAttribute('Id', 'CTe' . $chave);
         $this->infCte->setAttribute('versao', $std->versao);
@@ -4252,7 +4252,7 @@ class MakeCTeSimp
         $nNF = $ide->getElementsByTagName('nCT')->item(0)->nodeValue;
         $tpEmis = $ide->getElementsByTagName('tpEmis')->item(0)->nodeValue;
         $cCT = $ide->getElementsByTagName('cCT')->item(0)->nodeValue;
-        $chave = str_replace('CTe', '', $infCTe->getAttribute("Id"));
+        $chave = Keys::extractAccessKey($infCTe->getAttribute("Id"));
 
         $dt = new \DateTime($dhEmi);
 

--- a/src/MakeGTVe.php
+++ b/src/MakeGTVe.php
@@ -300,7 +300,7 @@ class MakeGTVe
      */
     public function taginfCTe($std)
     {
-        $chave = preg_replace('/[^0-9]/', '', $std->Id);
+        $chave = Keys::extractAccessKey($std->Id);
         $this->infCte = $this->dom->createElement('infCte');
         $this->infCte->setAttribute('Id', 'CTe' . $chave);
         $this->infCte->setAttribute('versao', $std->versao);
@@ -1806,7 +1806,7 @@ class MakeGTVe
         $nNF = $ide->getElementsByTagName('nCT')->item(0)->nodeValue;
         $tpEmis = $ide->getElementsByTagName('tpEmis')->item(0)->nodeValue;
         $cCT = $ide->getElementsByTagName('cCT')->item(0)->nodeValue;
-        $chave = str_replace('CTe', '', $infCTe->getAttribute("Id"));
+        $chave = Keys::extractAccessKey($infCTe->getAttribute("Id"));
 
         $dt = new \DateTime($dhEmi);
 

--- a/src/Tools.php
+++ b/src/Tools.php
@@ -17,6 +17,7 @@ namespace NFePHP\CTe;
  */
 
 use InvalidArgumentException;
+use NFePHP\Common\Keys;
 use NFePHP\Common\Signer;
 use NFePHP\Common\Strings;
 use NFePHP\Common\UFList;
@@ -649,7 +650,7 @@ class Tools extends ToolsCommon
         //verifica a validade no webservice da SEFAZ
         $tpAmb = $dom->getElementsByTagName('tpAmb')->item(0)->nodeValue;
         $infCTe = $dom->getElementsByTagName('infCte')->item(0);
-        $chCTe = preg_replace('/[^0-9]/', '', $infCTe->getAttribute("Id"));
+        $chCTe = Keys::extractAccessKey($infCTe->getAttribute("Id"));
         $protocol = $dom->getElementsByTagName('nProt')->item(0)->nodeValue;
         $digval = $dom->getElementsByTagName('DigestValue')->item(0)->nodeValue;
         //consulta o CTe


### PR DESCRIPTION
A Receita alterou a formacao do CNPJ (12 primeiras posicoes aceitam A-Z, DV numerico nas 2 ultimas). Os pontos que extraiam a chave de 44 posicoes do atributo Id (ou de $std->Id) usavam preg_replace('/[^0-9]/', '', ...) ou str_replace('CTe', '', ...), o que apagava silenciosamente as letras do CNPJ e corrompia a chave. Substitui todos esses pontos por Keys::extractAccessKey(), que usa o pattern alfanumerico oficial (sped-common >=5.1.17).

Ajusta o constraint de nfephp-org/sped-common para ^5.1.17, versao minima que traz Keys::extractAccessKey() e Keys::ACCESS_KEY_PATTERN.